### PR TITLE
catch merge error and return original extent

### DIFF
--- a/src/common/merge_extents.js
+++ b/src/common/merge_extents.js
@@ -7,8 +7,14 @@ module.exports = function (extent1, extent2) {
   if (typeof extent2 === 'string') {
     extent2 = JSON.parse(extent2);
   }
-  return turf.merge({
-    'type': 'FeatureCollection',
-    'features': [extent1, extent2]
-  });
+  try {
+    return turf.merge({
+      'type': 'FeatureCollection',
+      'features': [extent1, extent2]
+    });
+  } catch (err) {
+    // in case of merge error just return the first extent
+    console.log('Merge error: ', err);
+    return extent1;
+  }
 };


### PR DESCRIPTION
A few topology errors due to some sort of weird geometry when merging a user's new extent with their existing extent.

In case of these, seemingly rare, errors instead of failing return the original extent.  Presumably the error is due to the new geometry, not the old.