### PR TITLE
[WIP] Replace materialized views with incremental roll ups

### DIFF
--- a/sql/changesets.sql
+++ b/sql/changesets.sql
@@ -1,5 +1,4 @@
--- view with a schema that matches the legacy changesets table
-CREATE VIEW changesets AS
+CREATE TABLE changesets AS
   SELECT
     id,
     roads_added road_count_add,

--- a/sql/changesets_countries.sql
+++ b/sql/changesets_countries.sql
@@ -1,4 +1,4 @@
-CREATE VIEW changesets_countries AS
+CREATE TABLE changesets_countries AS
   SELECT
     changeset_id,
     country_id

--- a/sql/changesets_hashtags.sql
+++ b/sql/changesets_hashtags.sql
@@ -1,4 +1,4 @@
-CREATE VIEW changesets_hashtags AS
+CREATE TABLE changesets_hashtags AS
   SELECT
     changeset_id,
     hashtag_id

--- a/sql/countries.sql
+++ b/sql/countries.sql
@@ -1,4 +1,4 @@
-CREATE VIEW countries AS
+CREATE TABLE countries AS
   SELECT
     id,
     name,

--- a/sql/hashtag_stats.sql
+++ b/sql/hashtag_stats.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW hashtag_stats AS
+CREATE TABLE hashtag_stats AS
   SELECT
     hashtag,
     count(c.id) changesets,

--- a/sql/hashtags.sql
+++ b/sql/hashtags.sql
@@ -1,5 +1,5 @@
 -- view with a schema that matches the legacy hashtags table
-CREATE VIEW hashtags AS
+CREATE TABLE hashtags AS
   SELECT
     id,
     hashtag

--- a/sql/raw_countries_users.sql
+++ b/sql/raw_countries_users.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW raw_countries_users AS
+CREATE TABLE raw_countries_users AS
   SELECT
     country_id,
     user_id,

--- a/sql/raw_hashtags_users.sql
+++ b/sql/raw_hashtags_users.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW raw_hashtags_users AS
+CREATE TABLE raw_hashtags_users AS
   SELECT *,
     rank() OVER (ORDER BY edits DESC) edits_rank,
     rank() OVER (ORDER BY buildings DESC) buildings_rank,

--- a/sql/user_stats.sql
+++ b/sql/user_stats.sql
@@ -1,4 +1,4 @@
-CREATE MATERIALIZED VIEW user_stats AS
+CREATE TABLE user_stats AS
   SELECT
     user_id,
     name,

--- a/sql/users.sql
+++ b/sql/users.sql
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS postgis;
 
 -- view with a schema that matches the legacy users table
-CREATE VIEW users AS
+CREATE TABLE users AS
   SELECT
     id,
     u.name,

--- a/src/housekeeping.js
+++ b/src/housekeeping.js
@@ -19,71 +19,14 @@ const QUERIES = [
       sum(buildings_modified) buildings_modified,
       sum(pois_added) pois_added,
       sum(pois_modified) pois_modified,
-      sum(CASE
-        WHEN position('josm' in lower(editor)) > 0 THEN 1
-        ELSE 0
-        END) josm_edits, 
-      max(coalesce(closed_at, created_at)) updated_at
+      sum(pois_modified) josm_edits, 
+      max(coalesce(closed_at, created_at))  
     FROM raw_changesets_hashtags ch
     JOIN raw_changesets c ON c.id = ch.changeset_id
     JOIN raw_hashtags h ON h.id = ch.hashtag_id
-    GROUP BY hashtag;`,
-  `INSERT INTO raw_countries_users AS
-    SELECT
-      country_id,
-      user_id,
-      count(id) changesets
-    FROM raw_changesets_countries
-    JOIN raw_changesets ON raw_changesets.id = raw_changesets_countries.changeset_id
-    GROUP BY country_id, user_id;`,
-  `INSERT INTO raw_hashtags_users AS
-    SELECT *,
-      rank() OVER (ORDER BY edits DESC) edits_rank,
-      rank() OVER (ORDER BY buildings DESC) buildings_rank,
-      rank() OVER (ORDER BY road_km DESC) road_km_rank,
-      rank() OVER (ORDER BY updated_at DESC) updated_at_rank
-    FROM (
-      SELECT
-        raw_changesets_hashtags.hashtag_id,
-        raw_changesets.user_id,
-        count(id) changesets,
-        sum(buildings_added + buildings_modified + roads_added + roads_modified + waterways_added + waterways_modified + pois_added + pois_modified) edits,
-        sum(buildings_added + buildings_modified) buildings,
-        sum(roads_added + roads_modified) roads,
-        sum(road_km_added + road_km_modified) road_km,
-        max(coalesce(closed_at, created_at)) updated_at
-      FROM raw_changesets
-      JOIN raw_changesets_hashtags ON raw_changesets_hashtags.changeset_id = raw_changesets.id
-      GROUP BY hashtag_id, user_id
-    ) AS _;`,
-  `INSERT INTO user_stats AS
-    SELECT
-      user_id,
-      name,
-      count(raw_changesets.id) changesets,
-      sum(road_km_added) road_km_added,
-      sum(road_km_modified) road_km_modified,
-      sum(waterway_km_added) waterway_km_added,
-      sum(waterway_km_modified) waterway_km_modified,
-      sum(roads_added) roads_added,
-      sum(roads_modified) roads_modified,
-      sum(waterways_added) waterways_added,
-      sum(waterways_modified) waterways_modified,
-      sum(buildings_added) buildings_added,
-      sum(buildings_modified) buildings_modified,
-      sum(pois_added) pois_added,
-      sum(pois_modified) pois_modified,
-      sum(CASE
-        WHEN position('josm' in lower(editor)) > 0 THEN 1
-        ELSE 0
-        END) josm_edits,
-      (SELECT count(country_id) FROM raw_countries_users where raw_countries_users.user_id = raw_changesets.user_id) AS countries,
-      (SELECT count(hashtag_id) FROM raw_hashtags_users where raw_hashtags_users.user_id = raw_changesets.user_id) AS hashtags,
-      max(coalesce(closed_at, created_at)) updated_at
-    FROM raw_changesets
-    JOIN raw_users ON raw_changesets.user_id = raw_users.id
-    WHERE user_id IS NOT NULL
-    GROUP BY user_id, name;`
+    GROUP BY hashtag
+    ON CONFLICT do nothing;`
+  
 ];
 
 const query = async (pool, query) => {

--- a/src/housekeeping.js
+++ b/src/housekeeping.js
@@ -2,10 +2,88 @@ const env = require("require-env");
 const { Pool } = require("pg");
 
 const QUERIES = [
-  "REFRESH MATERIALIZED VIEW CONCURRENTLY hashtag_stats",
-  "REFRESH MATERIALIZED VIEW CONCURRENTLY raw_countries_users",
-  "REFRESH MATERIALIZED VIEW CONCURRENTLY raw_hashtags_users",
-  "REFRESH MATERIALIZED VIEW CONCURRENTLY user_stats"
+  `INSERT INTO hashtag_stats 
+    SELECT 
+      hashtag,
+      count(c.id) changesets,
+      count(distinct c.user_id) users,
+      sum(road_km_added) road_km_added,
+      sum(road_km_modified) road_km_modified,
+      sum(waterway_km_added) waterway_km_added,
+      sum(waterway_km_modified) waterway_km_modified,
+      sum(roads_added) roads_added,
+      sum(roads_modified) roads_modified,
+      sum(waterways_added) waterways_added,
+      sum(waterways_modified) waterways_modified,
+      sum(buildings_added) buildings_added,
+      sum(buildings_modified) buildings_modified,
+      sum(pois_added) pois_added,
+      sum(pois_modified) pois_modified,
+      sum(CASE
+        WHEN position('josm' in lower(editor)) > 0 THEN 1
+        ELSE 0
+        END) josm_edits, 
+      max(coalesce(closed_at, created_at)) updated_at
+    FROM raw_changesets_hashtags ch
+    JOIN raw_changesets c ON c.id = ch.changeset_id
+    JOIN raw_hashtags h ON h.id = ch.hashtag_id
+    GROUP BY hashtag;`,
+  `INSERT INTO raw_countries_users AS
+    SELECT
+      country_id,
+      user_id,
+      count(id) changesets
+    FROM raw_changesets_countries
+    JOIN raw_changesets ON raw_changesets.id = raw_changesets_countries.changeset_id
+    GROUP BY country_id, user_id;`,
+  `INSERT INTO raw_hashtags_users AS
+    SELECT *,
+      rank() OVER (ORDER BY edits DESC) edits_rank,
+      rank() OVER (ORDER BY buildings DESC) buildings_rank,
+      rank() OVER (ORDER BY road_km DESC) road_km_rank,
+      rank() OVER (ORDER BY updated_at DESC) updated_at_rank
+    FROM (
+      SELECT
+        raw_changesets_hashtags.hashtag_id,
+        raw_changesets.user_id,
+        count(id) changesets,
+        sum(buildings_added + buildings_modified + roads_added + roads_modified + waterways_added + waterways_modified + pois_added + pois_modified) edits,
+        sum(buildings_added + buildings_modified) buildings,
+        sum(roads_added + roads_modified) roads,
+        sum(road_km_added + road_km_modified) road_km,
+        max(coalesce(closed_at, created_at)) updated_at
+      FROM raw_changesets
+      JOIN raw_changesets_hashtags ON raw_changesets_hashtags.changeset_id = raw_changesets.id
+      GROUP BY hashtag_id, user_id
+    ) AS _;`,
+  `INSERT INTO user_stats AS
+    SELECT
+      user_id,
+      name,
+      count(raw_changesets.id) changesets,
+      sum(road_km_added) road_km_added,
+      sum(road_km_modified) road_km_modified,
+      sum(waterway_km_added) waterway_km_added,
+      sum(waterway_km_modified) waterway_km_modified,
+      sum(roads_added) roads_added,
+      sum(roads_modified) roads_modified,
+      sum(waterways_added) waterways_added,
+      sum(waterways_modified) waterways_modified,
+      sum(buildings_added) buildings_added,
+      sum(buildings_modified) buildings_modified,
+      sum(pois_added) pois_added,
+      sum(pois_modified) pois_modified,
+      sum(CASE
+        WHEN position('josm' in lower(editor)) > 0 THEN 1
+        ELSE 0
+        END) josm_edits,
+      (SELECT count(country_id) FROM raw_countries_users where raw_countries_users.user_id = raw_changesets.user_id) AS countries,
+      (SELECT count(hashtag_id) FROM raw_hashtags_users where raw_hashtags_users.user_id = raw_changesets.user_id) AS hashtags,
+      max(coalesce(closed_at, created_at)) updated_at
+    FROM raw_changesets
+    JOIN raw_users ON raw_changesets.user_id = raw_users.id
+    WHERE user_id IS NOT NULL
+    GROUP BY user_id, name;`
 ];
 
 const query = async (pool, query) => {


### PR DESCRIPTION
From https://github.com/AmericanRedCross/osm-stats/issues/56, started with replacing the materialized views approach. Here's what has been done so far:

- Use tables instead of views in sql scripts. Initially defined columns for table without populating data, but later just used the original select command to populate the table with data during the first housekeeping run
- Replaced refresh queries with upsert queries in js file.  There was a conflict in running the if condition for josm editor count. For now using the filled up with josm with dummy values.

On running housekeeping script with this modification I could see new updates in hashtag_stats
**Next Actions:**
- [ ] Talk through the approach w/ @mojodna 
- [ ] Identify and fix query related issues in src/houseekeeping.js

cc @dakotabenjamin @smit1678