### PR TITLE
Improve changeset parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -315,16 +315,19 @@
     },
     "ansi-regex": {
       "version": "2.1.1",
+      "resolved": false,
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
       "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
+      "resolved": false,
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
     },
     "argparse": {
       "version": "1.0.9",
+      "resolved": false,
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
@@ -354,6 +357,7 @@
     },
     "array-uniq": {
       "version": "1.0.3",
+      "resolved": false,
       "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
       "dev": true
     },
@@ -528,6 +532,7 @@
     },
     "balanced-match": {
       "version": "1.0.0",
+      "resolved": false,
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
@@ -734,6 +739,7 @@
     },
     "brace-expansion": {
       "version": "1.1.8",
+      "resolved": false,
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
@@ -1035,6 +1041,7 @@
     },
     "concat-map": {
       "version": "0.0.1",
+      "resolved": false,
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
@@ -1128,6 +1135,7 @@
     },
     "core-util-is": {
       "version": "1.0.2",
+      "resolved": false,
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
@@ -1436,6 +1444,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
+      "resolved": false,
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
@@ -2990,11 +2999,13 @@
     },
     "generate-function": {
       "version": "2.0.0",
+      "resolved": false,
       "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
       "dev": true
     },
     "generate-object-property": {
       "version": "1.2.0",
+      "resolved": false,
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
@@ -3236,6 +3247,7 @@
     },
     "has-ansi": {
       "version": "2.0.0",
+      "resolved": false,
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
@@ -3346,6 +3358,11 @@
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
+    "html-entities": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+      "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8="
+    },
     "htmlparser2": {
       "version": "3.9.2",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
@@ -3451,6 +3468,7 @@
     },
     "inherits": {
       "version": "2.0.3",
+      "resolved": false,
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
@@ -3759,6 +3777,7 @@
     },
     "is-property": {
       "version": "1.0.2",
+      "resolved": false,
       "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
       "dev": true
     },
@@ -3890,6 +3909,7 @@
     },
     "jsonpointer": {
       "version": "4.0.1",
+      "resolved": false,
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
     },
@@ -4161,6 +4181,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -4168,6 +4189,7 @@
     },
     "ms": {
       "version": "2.0.0",
+      "resolved": false,
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
@@ -6726,6 +6748,7 @@
     },
     "pinkie": {
       "version": "2.0.4",
+      "resolved": false,
       "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
       "dev": true
     },
@@ -6784,6 +6807,7 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
+      "resolved": false,
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
@@ -6801,6 +6825,7 @@
     },
     "process-nextick-args": {
       "version": "1.0.7",
+      "resolved": false,
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "progress": {
@@ -7152,6 +7177,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.2",
+          "resolved": false,
           "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
@@ -7165,6 +7191,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
+          "resolved": false,
           "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
@@ -7199,6 +7226,7 @@
     },
     "safe-buffer": {
       "version": "5.1.1",
+      "resolved": false,
       "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "sax": {
@@ -7545,6 +7573,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
+      "resolved": false,
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
@@ -7754,6 +7783,7 @@
     },
     "supports-color": {
       "version": "2.0.0",
+      "resolved": false,
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
@@ -8229,6 +8259,7 @@
     },
     "type-check": {
       "version": "0.3.2",
+      "resolved": false,
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
@@ -8566,6 +8597,7 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
+      "resolved": false,
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
@@ -8664,6 +8696,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
+      "resolved": false,
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
@@ -8719,6 +8752,7 @@
     },
     "xtend": {
       "version": "4.0.1",
+      "resolved": false,
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "epipebomb": "^1.0.0",
     "geojson-rbush": "^3.1.0",
     "highland": "^2.11.1",
+    "html-entities": "^1.2.1",
     "martinez-polygon-clipping": "^0.5.0",
     "osm-replication-streams": "^0.6.3",
     "osm2obj": "^3.0.0",

--- a/src/stats.js
+++ b/src/stats.js
@@ -5,6 +5,7 @@ require("core-js/features/array/flat");
 const _ = require("highland");
 const async = require("async");
 const env = require("require-env");
+var htmlEntities = require("html-entities").AllHtmlEntities;
 const OSMParser = require("osm2obj");
 const {
   parsers: { AugmentedDiffParser },
@@ -209,10 +210,16 @@ SET id=$1,
 // from https://github.com/openstreetmap/iD/blob/45ffa3b731463bf4eba52519896ad33653def0cd/modules/ui/commit.js
 const HASHTAG_REGEX = /(#[^\u2000-\u206F\u2E00-\u2E7F\s\\'!"#$%()*,./:;<=>?@[\]^`{|}~]+)/g;
 
-const extractHashtags = tags =>
-  ((tags.comment || "").match(HASHTAG_REGEX) || []).map(x =>
-    x.slice(1).toLowerCase()
+const extractHashtags = tags => {
+  tags.comment = htmlEntities.decode(tags.comment);
+  ((tags.comment || "").match(HASHTAG_REGEX) || []).map(
+    function(x) {
+      x.slice(1).toLowerCase();
+    }
+ 
   );
+}
+  
 
 const changesetUpdater = changeset => {
   const {

--- a/src/stats.js
+++ b/src/stats.js
@@ -211,16 +211,10 @@ SET id=$1,
 const HASHTAG_REGEX = /(#[^\u2000-\u206F\u2E00-\u2E7F\s\\'!"#$%()*,./:;<=>?@[\]^`{|}~]+)/g
 
 const extractHashtags = tags => {
-  tags.comment = htmlEntities.decode(tags.comment);
-  ((tags.comment || '').match(HASHTAG_REGEX) || []).map(
-    (x) => {
-      x = x.slice(1).toLowerCase()
-      return x
-    }
-
-  )
+  tags.comment = htmlEntities.decode(tags.comment)
+  return ((tags.comment || "").match(HASHTAG_REGEX) || []).map(x =>
+    x.slice(1).toLowerCase());
 }
-
 
 const changesetUpdater = changeset => {
   const {

--- a/src/stats.js
+++ b/src/stats.js
@@ -213,7 +213,7 @@ const HASHTAG_REGEX = /(#[^\u2000-\u206F\u2E00-\u2E7F\s\\'!"#$%()*,./:;<=>?@[\]^
 const extractHashtags = tags => {
   tags.comment = htmlEntities.decode(tags.comment);
   ((tags.comment || '').match(HASHTAG_REGEX) || []).map(
-    function (x) {
+    (x) => {
       x = x.slice(1).toLowerCase()
       return x
     }

--- a/src/stats.js
+++ b/src/stats.js
@@ -1,70 +1,70 @@
 // for osm-replication-streams on Node < 8
-require("babel-polyfill");
-require("core-js/features/array/flat");
+require('babel-polyfill')
+require('core-js/features/array/flat')
 
-const _ = require("highland");
-const async = require("async");
-const env = require("require-env");
-var htmlEntities = require("html-entities").AllHtmlEntities;
-const OSMParser = require("osm2obj");
+const _ = require('highland')
+const async = require('async')
+const env = require('require-env')
+const htmlEntities = require('html-entities').AllHtmlEntities
+const OSMParser = require('osm2obj')
 const {
   parsers: { AugmentedDiffParser },
   sources: { AugmentedDiffs, Changesets }
-} = require("osm-replication-streams");
-const { Pool } = require("pg");
+} = require('osm-replication-streams')
+const { Pool } = require('pg')
 
-const { NOOP } = require(".");
-const StatsStream = require("./stats_stream");
+const { NOOP } = require('.')
+const StatsStream = require('./stats_stream')
 
-const OVERPASS_URL = process.env.OVERPASS_URL || "http://overpass-api.de";
+const OVERPASS_URL = process.env.OVERPASS_URL || 'http://overpass-api.de';
 
 const pool = new Pool({
-  connectionString: env.require("DATABASE_URL")
-});
+  connectionString: env.require('DATABASE_URL')
+})
 
-pool.on("error", err => {
-  console.warn("Unexpected error on idle client", err);
-  throw err;
-});
+pool.on('error', err => {
+  console.warn('Unexpected error on idle client', err)
+  throw err
+})
 
 const query = (q, params, callback) =>
   pool.connect((err, client, release) => {
-    if (typeof params === "function") {
-      callback = params;
-      params = null;
+    if (typeof params === 'function') {
+      callback = params
+      params = null
     }
 
-    callback = callback || NOOP;
+    callback = callback || NOOP
 
     if (err) {
-      console.warn(err);
-      release();
-      return callback(err);
+      console.warn(err)
+      release()
+      return callback(err)
     }
 
     return client.query(q, params, (err, results) => {
-      release();
-      return callback(err, results);
-    });
-  });
+      release()
+      return callback(err, results)
+    })
+  })
 
 const join = (a, b) => {
-  if (typeof a === "number" || typeof b === "number") {
-    return (a || 0) + (b || 0);
+  if (typeof a === 'number' || typeof b === 'number') {
+    return (a || 0) + (b || 0)
   }
 
   if (Array.isArray(a) || Array.isArray(b)) {
-    return Array.from(new Set(a || [].concat(b)));
+    return Array.from(new Set(a || [].concat(b)))
   }
 
-  throw new Error(`Don't know how to join: '${a}', '${b}'`);
+  throw new Error(`Don't know how to join: '${a}', '${b}'`)
 };
 
 const merge = (a, b) =>
   Object.keys(b).reduce(
     (acc, k) => Object.assign({}, acc, { [k]: join(acc[k], b[k]) }),
     a
-  );
+  )
 
 const summarizer = batch =>
   batch.reduce(
@@ -76,7 +76,7 @@ const summarizer = batch =>
         })
       }),
     {}
-  );
+  )
 
 const statUpdater = stats => {
   const lastAugmentedDiff = Math.max.apply(
@@ -89,9 +89,9 @@ const statUpdater = stats => {
         )
       )
     )
-  );
+  )
 
-  console.warn(`Checkpointing augmented diffs @ ${lastAugmentedDiff}.`);
+  console.warn(`Checkpointing augmented diffs @ ${lastAugmentedDiff}.`)
 
   const queries = Object.keys(stats)
     .map(changeset =>
@@ -196,7 +196,7 @@ SET id=$1,
           ]
         ])
     )
-    .reduce((acc, a) => acc.concat(a), []);
+    .reduce((acc, a) => acc.concat(a), [])
 
   return _(push =>
     async.each(
@@ -204,22 +204,23 @@ SET id=$1,
       ([q, params], done) => query(q, params, done),
       err => push(err, _.nil)
     )
-  );
+  )
 };
 
 // from https://github.com/openstreetmap/iD/blob/45ffa3b731463bf4eba52519896ad33653def0cd/modules/ui/commit.js
-const HASHTAG_REGEX = /(#[^\u2000-\u206F\u2E00-\u2E7F\s\\'!"#$%()*,./:;<=>?@[\]^`{|}~]+)/g;
+const HASHTAG_REGEX = /(#[^\u2000-\u206F\u2E00-\u2E7F\s\\'!"#$%()*,./:;<=>?@[\]^`{|}~]+)/g
 
 const extractHashtags = tags => {
   tags.comment = htmlEntities.decode(tags.comment);
-  ((tags.comment || "").match(HASHTAG_REGEX) || []).map(
-    function(x) {
-      x.slice(1).toLowerCase();
+  ((tags.comment || '').match(HASHTAG_REGEX) || []).map(
+    function (x) {
+      x = x.slice(1).toLowerCase()
+      return x
     }
- 
-  );
+
+  )
 }
-  
+
 
 const changesetUpdater = changeset => {
   const {
@@ -228,13 +229,13 @@ const changesetUpdater = changeset => {
     closed_at: closedAt,
     uid,
     user
-  } = changeset;
-  let editor = null;
-  let hashtags = [];
+  } = changeset
+  let editor = null
+  let hashtags = []
 
   if (changeset.tags != null) {
-    editor = changeset.tags.created_by;
-    hashtags = extractHashtags(changeset.tags);
+    editor = changeset.tags.created_by
+    hashtags = extractHashtags(changeset.tags)
   }
 
   const queries = [
@@ -288,7 +289,7 @@ WHERE u.id = $1
       `,
       [uid, user]
     ]
-  ];
+  ]
 
   return _(push => {
     async.series(
@@ -322,7 +323,7 @@ JOIN raw_hashtags USING(hashtag)
                 [hashtag]
               ),
               (result, fin) => {
-                const { id: hashtagId } = result.rows[0];
+                const { id: hashtagId } = result.rows[0]
 
                 return query(
                   `
@@ -334,7 +335,7 @@ ON CONFLICT DO NOTHING
                   `,
                   [id, hashtagId],
                   fin
-                );
+                )
               }
             ],
             done
@@ -342,21 +343,21 @@ ON CONFLICT DO NOTHING
         )
       ],
       err => push(err, _.nil)
-    );
-  });
+    )
+  })
 };
 
 const getInitialAugmentedDiffSequenceNumber = callback =>
-  query("SELECT id FROM augmented_diff_status", (err, results) => {
+  query('SELECT id FROM augmented_diff_status', (err, results) => {
     if (err) {
-      return callback(err);
+      return callback(err)
     }
 
-    return callback(null, results.rows[0].id);
-  });
+    return callback(null, results.rows[0].id)
+  })
 
 const checkpointChangesets = sequenceNumber => {
-  console.warn(`Checkpointing changesets @ ${sequenceNumber}.`);
+  console.warn(`Checkpointing changesets @ ${sequenceNumber}.`)
 
   query(
     `
@@ -367,20 +368,20 @@ SET id=$1,
     [Number(sequenceNumber)],
     err => {
       if (err) {
-        console.warn(err.stack);
+        console.warn(err.stack)
       }
     }
-  );
+  )
 };
 
 const getInitialChangesetSequenceNumber = callback =>
-  query("SELECT id FROM changesets_status", (err, results) => {
+  query('SELECT id FROM changesets_status', (err, results) => {
     if (err) {
-      return callback(err);
+      return callback(err)
     }
 
-    return callback(null, results.rows[0].id);
-  });
+    return callback(null, results.rows[0].id)
+  })
 
 module.exports = (options, callback) => {
   const opts = Object.assign(
@@ -390,9 +391,9 @@ module.exports = (options, callback) => {
       infinite: true
     },
     options
-  );
+  )
 
-  callback = callback || NOOP;
+  callback = callback || NOOP
 
   return async.parallel(
     {
@@ -404,7 +405,7 @@ module.exports = (options, callback) => {
       { initialAugmentedDiffSequenceNumber, initialChangesetSequenceNumber }
     ) => {
       if (err) {
-        return callback(err);
+        return callback(err)
       }
 
       return async.parallel(
@@ -417,57 +418,57 @@ module.exports = (options, callback) => {
                 infinite: opts.infinite,
                 delay: opts.delay
               })
-                .pipe(new AugmentedDiffParser().on("error", console.warn))
+                .pipe(new AugmentedDiffParser().on('error', console.warn))
                 .pipe(new StatsStream())
             )
               // batch by sequence
               .through(s => {
-                let batched = [];
-                let sequence = null;
+                let batched = []
+                let sequence = null
 
                 return s.consume((err, x, push, next) => {
                   if (err) {
-                    push(err);
-                    return next();
+                    push(err)
+                    return next()
                   }
 
                   if (x === _.nil) {
                     // end of the stream; flush
                     if (batched.length > 0) {
-                      push(null, batched);
+                      push(null, batched)
                     }
 
-                    return push(null, _.nil);
+                    return push(null, _.nil)
                   }
 
-                  let activeSequence = sequence;
+                  let activeSequence = sequence
 
                   if (x.stats != null) {
-                    [activeSequence] = x.stats.augmentedDiffs;
+                    [activeSequence] = x.stats.augmentedDiffs
                   }
 
-                  if (x.type === "Marker" || sequence !== activeSequence) {
+                  if (x.type === 'Marker' || sequence !== activeSequence) {
                     // new sequence; flush previous
                     if (batched.length > 0) {
-                      push(null, batched);
+                      push(null, batched)
                     }
 
                     // reset batch
-                    if (x.type !== "Marker") {
-                      batched = [x];
+                    if (x.type !== 'Marker') {
+                      batched = [x]
                     } else {
-                      batched = [];
+                      batched = []
                     }
-                    sequence = activeSequence;
+                    sequence = activeSequence
 
-                    return next();
+                    return next()
                   }
 
                   // add this item to the batch
-                  batched.push(x);
+                  batched.push(x)
 
-                  return next();
-                });
+                  return next()
+                })
               })
               .map(summarizer)
               .flatMap(statUpdater)
@@ -489,7 +490,7 @@ module.exports = (options, callback) => {
               .done(() => done)
         ],
         callback
-      );
+      )
     }
-  );
+  )
 };


### PR DESCRIPTION
Per @mojodna's comment in #46 - using `html-entities` fixed the `&` issue. Ran this locally to cover problematic changesets and hashtags. This library helped in decoding the hashtags without the line feed character.

Thanks for the heads up @mojodna 🙇‍♀ If not this, I was thinking of looking at `osm2obj` library, but your tip saved time.
